### PR TITLE
Add support for typed Custom Objects

### DIFF
--- a/commercetools-sdk-java-api-customtypes-generator/build.gradle.kts
+++ b/commercetools-sdk-java-api-customtypes-generator/build.gradle.kts
@@ -3,6 +3,7 @@ description = "Code generator for custom types defined in commercetools projects
 dependencies {
     implementation("com.squareup:kotlinpoet:1.11.0")
     api("com.commercetools.sdk:commercetools-sdk-java-api:8.4.0")
+    implementation("net.pwall.json:json-kotlin-schema-codegen:0.73")
 
     testImplementation("com.github.tschuchortdev:kotlin-compile-testing:1.4.8")
     testImplementation("org.assertj:assertj-core:3.22.0")

--- a/commercetools-sdk-java-api-customtypes-generator/build.gradle.kts
+++ b/commercetools-sdk-java-api-customtypes-generator/build.gradle.kts
@@ -3,7 +3,6 @@ description = "Code generator for custom types defined in commercetools projects
 dependencies {
     implementation("com.squareup:kotlinpoet:1.11.0")
     api("com.commercetools.sdk:commercetools-sdk-java-api:8.4.0")
-    implementation("net.pwall.json:json-kotlin-schema-codegen:0.73")
 
     testImplementation("com.github.tschuchortdev:kotlin-compile-testing:1.4.8")
     testImplementation("org.assertj:assertj-core:3.22.0")

--- a/commercetools-sdk-java-api-customtypes-generator/src/main/kotlin/de/akii/commercetools/api/customtypes/generator/common/classReferences.kt
+++ b/commercetools-sdk-java-api-customtypes-generator/src/main/kotlin/de/akii/commercetools/api/customtypes/generator/common/classReferences.kt
@@ -76,3 +76,23 @@ class CustomFieldsTypeResolver(config: Configuration) :
 class TypedResourceDeserializer(typedResources: TypedResources) : ClassReference(
     typedResources.packageName,
     "Typed${typedResources.resourceInterface.simpleName}Deserializer")
+
+class TypedCustomObjectInterface(config: Configuration) :
+    ClassReference("${config.packageName}.custom_objects", "TypedCustomObject")
+
+class TypedCustomObject(containerName: String, className: String, config: Configuration) : ClassReference(
+    "${config.packageName}.custom_objects",
+    config.containerNameToClassName(containerName, className))
+
+class TypedCustomObjectValue(className: String) : ClassReference(
+    className.substringBeforeLast('.'),
+    className.substringAfterLast('.'))
+
+class TypedCustomObjectsDeserializer(config: Configuration) :
+    ClassReference("${config.packageName}.custom_objects", "TypedCustomObjectsDeserializer")
+
+class TypedCustomObjectsBeanDeserializerModifier(config: Configuration) :
+    ClassReference("${config.packageName}.custom_objects", "TypedCustomObjectsBeanDeserializerModifier")
+
+class TypedCustomObjectsDelegatingDeserializer(config: Configuration) :
+    ClassReference("${config.packageName}.custom_objects", "TypedCustomObjectsDelegatingDeserializer")

--- a/commercetools-sdk-java-api-customtypes-generator/src/main/kotlin/de/akii/commercetools/api/customtypes/generator/common/configuration.kt
+++ b/commercetools-sdk-java-api-customtypes-generator/src/main/kotlin/de/akii/commercetools/api/customtypes/generator/common/configuration.kt
@@ -4,7 +4,6 @@ import com.commercetools.api.models.product_type.AttributeDefinition
 import com.commercetools.api.models.product_type.ProductType
 import com.commercetools.api.models.type.FieldDefinition
 import com.commercetools.api.models.type.Type
-import java.io.File
 
 enum class ProductClassType {
     Product, ProductCatalogData, ProductData, ProductVariant, ProductVariantAttributes
@@ -14,7 +13,7 @@ data class Configuration(
     val packageName: String,
     val productTypes: List<ProductType>,
     val customTypes: List<Type>,
-    val customObjectTypes: Map<String, File>,
+    val customObjectTypes: Map<String, String>,
 
     val productTypeToKey: (productType: ProductType) -> String = ::productTypeToKey,
     val productTypeToClassName: (productType: ProductType, productClassType: ProductClassType) -> String = ::productTypeToClassName,
@@ -25,7 +24,9 @@ data class Configuration(
     val typeToCustomFieldsClassName: (type: Type) -> String = ::typeToCustomFieldsClassName,
     val typeToResourceClassName: (type: Type, referenceTypeName: String) -> String = ::typeToResourceClassName,
     val fieldToPropertyName: (type: Type, fieldDefinition: FieldDefinition) -> String = ::fieldToPropertyName,
-    val isFieldRequired: (type: Type, fieldDefinition: FieldDefinition) -> Boolean = ::isFieldRequired
+    val isFieldRequired: (type: Type, fieldDefinition: FieldDefinition) -> Boolean = ::isFieldRequired,
+
+    val containerNameToClassName: (containerName: String, className: String) -> String = ::containerNameToClassName
 )
 
 fun productTypeToKey(productType: ProductType): String =
@@ -73,3 +74,7 @@ fun fieldToPropertyName(@Suppress("UNUSED_PARAMETER") type: Type, fieldDefinitio
 fun isFieldRequired(
     @Suppress("UNUSED_PARAMETER") type: Type,
     @Suppress("UNUSED_PARAMETER") fieldDefinition: FieldDefinition): Boolean = false
+
+fun containerNameToClassName(
+    @Suppress("UNUSED_PARAMETER") containerName: String,
+    className: String): String = "${className.substringAfterLast('.')}CustomObject"

--- a/commercetools-sdk-java-api-customtypes-generator/src/main/kotlin/de/akii/commercetools/api/customtypes/generator/common/configuration.kt
+++ b/commercetools-sdk-java-api-customtypes-generator/src/main/kotlin/de/akii/commercetools/api/customtypes/generator/common/configuration.kt
@@ -4,6 +4,7 @@ import com.commercetools.api.models.product_type.AttributeDefinition
 import com.commercetools.api.models.product_type.ProductType
 import com.commercetools.api.models.type.FieldDefinition
 import com.commercetools.api.models.type.Type
+import java.io.File
 
 enum class ProductClassType {
     Product, ProductCatalogData, ProductData, ProductVariant, ProductVariantAttributes
@@ -13,6 +14,7 @@ data class Configuration(
     val packageName: String,
     val productTypes: List<ProductType>,
     val customTypes: List<Type>,
+    val customObjectTypes: Map<String, File>,
 
     val productTypeToKey: (productType: ProductType) -> String = ::productTypeToKey,
     val productTypeToClassName: (productType: ProductType, productClassType: ProductClassType) -> String = ::productTypeToClassName,

--- a/commercetools-sdk-java-api-customtypes-generator/src/main/kotlin/de/akii/commercetools/api/customtypes/generator/deserialization/apiModules.kt
+++ b/commercetools-sdk-java-api-customtypes-generator/src/main/kotlin/de/akii/commercetools/api/customtypes/generator/deserialization/apiModules.kt
@@ -1,5 +1,7 @@
 package de.akii.commercetools.api.customtypes.generator.deserialization
 
+import com.commercetools.api.models.custom_object.CustomObject
+import com.commercetools.api.models.custom_object.CustomObjectImpl
 import com.commercetools.api.models.product.Product
 import com.commercetools.api.models.product.ProductImpl
 import com.commercetools.api.models.product_type.ProductType
@@ -107,6 +109,34 @@ fun typedResourcesApiModule(typedResourceFiles: List<TypedResources>, config: Co
         })
         .build()
 
+fun typedCustomObjectsApiModule(config: Configuration): TypeSpec =
+    TypeSpec
+        .classBuilder(ClassName(config.packageName, "TypedCustomObjectsApiModule"))
+        .addAnnotation(generated)
+        .superclass(SimpleModule::class)
+        .addInitializerBlock(buildCodeBlock {
+            add(
+                "addDeserializer(%1T::class.java, %2T())\n",
+                CustomObject::class,
+                TypedCustomObjectsDeserializer(config).className
+            )
+            add(
+                "setMixInAnnotation(%1T::class.java, %2L::class.java)\n",
+                CustomObject::class,
+                "CustomObjectMixIn"
+            )
+            add(
+                "setMixInAnnotation(%1T::class.java, %2L::class.java)\n",
+                CustomObjectImpl::class,
+                "FallbackCustomObjectMixIn"
+            )
+            add(
+                "setDeserializerModifier(%1T())\n",
+                TypedCustomObjectsBeanDeserializerModifier(config).className,
+            )
+        })
+        .build()
+
 fun productMixInInterface(config: Configuration): TypeSpec =
     TypeSpec
         .interfaceBuilder(ClassName(config.packageName, "ProductMixIn"))
@@ -133,4 +163,18 @@ fun fallbackResourceInterface(typedResourceFile: TypedResources, config: Configu
         .interfaceBuilder(ClassName(config.packageName, "Fallback${typedResourceFile.resourceInterface.simpleName}MixIn"))
         .addAnnotation(generated)
         .addAnnotation(deserializeAs(typedResourceFile.resourceDefaultImplementation.asClassName()))
+        .build()
+
+fun customObjectMixInInterface(config: Configuration): TypeSpec =
+    TypeSpec
+        .interfaceBuilder(ClassName(config.packageName, "CustomObjectMixIn"))
+        .addAnnotation(generated)
+        .addAnnotation(deserializeAs(CustomObject::class.asClassName()))
+        .build()
+
+fun fallbackCustomObjectInterface(config: Configuration) =
+    TypeSpec
+        .interfaceBuilder(ClassName(config.packageName, "FallbackCustomObjectMixIn"))
+        .addAnnotation(generated)
+        .addAnnotation(deserializeAs(CustomObjectImpl::class.asClassName()))
         .build()

--- a/commercetools-sdk-java-api-customtypes-generator/src/main/kotlin/de/akii/commercetools/api/customtypes/generator/deserialization/customObject.kt
+++ b/commercetools-sdk-java-api-customtypes-generator/src/main/kotlin/de/akii/commercetools/api/customtypes/generator/deserialization/customObject.kt
@@ -1,0 +1,130 @@
+package de.akii.commercetools.api.customtypes.generator.deserialization
+
+import com.commercetools.api.models.custom_object.CustomObject
+import com.commercetools.api.models.custom_object.CustomObjectImpl
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.*
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier
+import com.fasterxml.jackson.databind.deser.std.DelegatingDeserializer
+import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import de.akii.commercetools.api.customtypes.generator.common.*
+
+fun typedCustomObjectDeserializer(config: Configuration): TypeSpec =
+    TypeSpec
+        .classBuilder(TypedCustomObjectsDeserializer(config).className)
+        .addAnnotation(generated)
+        .superclass(JsonDeserializer::class.asTypeName().parameterizedBy(CustomObject::class.asTypeName()))
+        .addFunction(deserialize(config))
+        .addFunction(makeParser)
+        .build()
+
+fun typedCustomObjectsBeanDeserializerModifier(config: Configuration): TypeSpec =
+    TypeSpec
+        .classBuilder(TypedCustomObjectsBeanDeserializerModifier(config).className)
+        .addAnnotation(generated)
+        .superclass(BeanDeserializerModifier::class)
+        .addFunction(FunSpec
+            .builder("modifyDeserializer")
+            .addModifiers(KModifier.OVERRIDE)
+            .addParameter("config", DeserializationConfig::class.asTypeName().copy(nullable = true))
+            .addParameter("beanDesc", BeanDescription::class.asTypeName().copy(nullable = true))
+            .addParameter("deserializer", jsonDeserializerType)
+            .addCode("""
+                    return if (beanDesc?.type?.isTypeOrSubTypeOf(%1T::class.java) == true)
+                        super.modifyDeserializer(config, beanDesc, %2T(deserializer))
+                    else
+                        super.modifyDeserializer(config, beanDesc, deserializer)
+                """.trimIndent(),
+                TypedCustomObjectInterface(config).className,
+                TypedCustomObjectsDelegatingDeserializer(config).className,
+            )
+            .returns(jsonDeserializerType)
+            .build()
+        )
+        .build()
+
+fun typedCustomObjectsDelegatingDeserializer(config: Configuration): TypeSpec =
+    TypeSpec
+        .classBuilder(TypedCustomObjectsDelegatingDeserializer(config).className)
+        .addAnnotation(generated)
+        .primaryConstructor(FunSpec
+            .constructorBuilder()
+            .addParameter("d", jsonDeserializerType)
+            .build()
+        )
+        .superclass(DelegatingDeserializer::class)
+        .addSuperclassConstructorParameter("d")
+        .addFunction(newDelegatingInstance(config))
+        .addFunction(transformJson)
+        .addFunction(makeParser)
+        .build()
+
+private fun deserialize(config: Configuration): FunSpec =
+    FunSpec
+        .builder("deserialize")
+        .addModifiers(KModifier.OVERRIDE)
+        .addParameter("p", JsonParser::class.asTypeName().copy(true))
+        .addParameter("ctxt", DeserializationContext::class.asTypeName().copy(true))
+        .addCode("""
+            val codec = p?.codec
+            val node: com.fasterxml.jackson.databind.JsonNode? = codec?.readTree(p)
+            val containerName: String? = node?.path("container")?.asText()
+
+        """.trimIndent())
+        .addCode(generateContainerNameToTypeMap(config))
+        .returns(CustomObject::class.asTypeName().copy(nullable = true))
+        .build()
+
+private fun generateContainerNameToTypeMap(config: Configuration): CodeBlock {
+    val whenExpression = CodeBlock
+        .builder()
+        .add("return when (containerName) {\n")
+        .add("⇥")
+
+    config.customObjectTypes.forEach { (containerName, className) ->
+        whenExpression.add(
+            "%1S -> ctxt?.readValue(makeParser(node, codec), %2T::class.java)\n",
+            containerName,
+            TypedCustomObject(containerName, className, config).className
+        )
+    }
+
+    return whenExpression
+        .add("else -> ctxt?.readValue(makeParser(node, codec), %T::class.java)\n", CustomObjectImpl::class)
+        .add("⇤")
+        .add("}")
+        .build()
+}
+
+private fun newDelegatingInstance(config: Configuration) =
+    FunSpec
+        .builder("newDelegatingInstance")
+        .addModifiers(KModifier.OVERRIDE)
+        .addParameter("newDelegatee", jsonDeserializerType)
+        .addStatement(
+            "return %1T(newDelegatee)",
+            TypedCustomObjectsDelegatingDeserializer(config).className
+        )
+        .returns(jsonDeserializerType)
+        .build()
+
+private val transformJson =
+    FunSpec
+        .builder("deserialize")
+        .addModifiers(KModifier.OVERRIDE)
+        .addParameter("p", JsonParser::class.asTypeName().copy(true))
+        .addParameter("ctxt", DeserializationContext::class.asTypeName().copy(true))
+        .addCode("""
+            val codec = p?.codec
+            val node: com.fasterxml.jackson.databind.JsonNode? = codec?.readTree(p)
+            val objectNode = node as com.fasterxml.jackson.databind.node.ObjectNode
+            val wrapperObject = objectNode.objectNode()
+
+            wrapperObject.set<JsonNode>("delegate", objectNode)
+            wrapperObject.set<JsonNode>("value", objectNode.get("value"))
+
+            return super.deserialize(makeParser(wrapperObject, codec), ctxt)
+        """.trimIndent())
+        .returns(Any::class)
+        .build()

--- a/commercetools-sdk-java-api-customtypes-generator/src/main/kotlin/de/akii/commercetools/api/customtypes/generator/deserializationFiles.kt
+++ b/commercetools-sdk-java-api-customtypes-generator/src/main/kotlin/de/akii/commercetools/api/customtypes/generator/deserializationFiles.kt
@@ -19,6 +19,10 @@ fun deserializationFiles(typedResourceFiles: List<TypedResources>, config: Confi
         files.add(typedResourcesDeserializerFile(config))
     }
 
+    if (config.customObjectTypes.isNotEmpty()) {
+        files.add(typedCustomObjectsDeserializerFile(config))
+    }
+
     return files
 }
 
@@ -40,6 +44,12 @@ fun apiModulesFile(typedResourceFiles: List<TypedResources>, config: Configurati
             file.addType(fallbackResourceInterface(it, config))
         }
         file.addType(typedResourcesApiModule(typedResourceFiles, config))
+    }
+
+    if (config.customObjectTypes.isNotEmpty()) {
+        file.addType(customObjectMixInInterface(config))
+        file.addType(fallbackCustomObjectInterface(config))
+        file.addType(typedCustomObjectsApiModule(config))
     }
 
     return file.build()
@@ -72,4 +82,12 @@ fun typedResourcesDeserializerFile(config: Configuration) =
         .addType(typedCustomFieldsTypeResolver(config))
         .addType(typedCustomFieldsBeanDeserializerModifier(config))
         .addType(typedCustomFieldsDelegatingDeserializer(config))
+        .build()
+
+fun typedCustomObjectsDeserializerFile(config: Configuration) =
+    FileSpec
+        .builder("${config.packageName}.custom_objects", "deserializer")
+        .addType(typedCustomObjectDeserializer(config))
+        .addType(typedCustomObjectsBeanDeserializerModifier(config))
+        .addType(typedCustomObjectsDelegatingDeserializer(config))
         .build()

--- a/commercetools-sdk-java-api-customtypes-generator/src/main/kotlin/de/akii/commercetools/api/customtypes/generator/model/customObjects.kt
+++ b/commercetools-sdk-java-api-customtypes-generator/src/main/kotlin/de/akii/commercetools/api/customtypes/generator/model/customObjects.kt
@@ -1,0 +1,68 @@
+package de.akii.commercetools.api.customtypes.generator.model
+
+import com.commercetools.api.models.custom_object.CustomObject
+import com.commercetools.api.models.custom_object.CustomObjectImpl
+import com.squareup.kotlinpoet.*
+import de.akii.commercetools.api.customtypes.generator.common.*
+
+fun typedCustomObjectInterface(config: Configuration): TypeSpec =
+    TypeSpec
+        .interfaceBuilder(TypedCustomObjectInterface(config).className)
+        .addAnnotation(generated)
+        .build()
+
+fun typedCustomObject(containerName: String, className: String, config: Configuration): Pair<ClassName, TypeSpec> {
+    val typedCustomObjectClassName = TypedCustomObject(containerName, className, config).className
+    val valueClassName = TypedCustomObjectValue(className)
+
+    return typedCustomObjectClassName to TypeSpec
+        .classBuilder(typedCustomObjectClassName)
+        .addAnnotation(generated)
+        .addAnnotation(deserializeAs(typedCustomObjectClassName))
+        .primaryConstructor(
+            FunSpec
+                .constructorBuilder()
+                .addAnnotation(jsonCreator)
+                .addParameter(
+                    ParameterSpec
+                        .builder("delegate", CustomObjectImpl::class)
+                        .addAnnotation(jsonProperty("delegate"))
+                        .build()
+                )
+                .addParameter(
+                    ParameterSpec
+                        .builder("value", valueClassName.className)
+                        .addAnnotation(jsonProperty("value"))
+                        .build()
+                )
+                .build()
+        )
+        .addSuperinterface(CustomObject::class, "delegate")
+        .addSuperinterface(TypedCustomObjectInterface(config).className)
+        .addProperty(
+            PropertySpec
+                .builder("value", valueClassName.className)
+                .initializer("value")
+                .addModifiers(KModifier.PRIVATE)
+                .build()
+        )
+        .addFunction(
+            FunSpec
+                .builder("getValue")
+                .returns(valueClassName.className)
+                .addStatement("return this.value")
+                .addModifiers(KModifier.OVERRIDE)
+                .build()
+        )
+        .addType(TypeSpec
+            .companionObjectBuilder()
+            .addProperty(PropertySpec
+                .builder("CONTAINER_NAME", String::class)
+                .addModifiers(KModifier.CONST)
+                .initializer("%S", containerName)
+                .build()
+            )
+            .build()
+        )
+        .build()
+}

--- a/commercetools-sdk-java-api-customtypes-generator/src/main/kotlin/de/akii/commercetools/api/customtypes/generator/modelFiles.kt
+++ b/commercetools-sdk-java-api-customtypes-generator/src/main/kotlin/de/akii/commercetools/api/customtypes/generator/modelFiles.kt
@@ -13,8 +13,9 @@ fun modelFiles(typedResources: List<TypedResources>, config: Configuration): Lis
     listOf(
         productCommonFile(config),
         customFieldsFile(config),
-        typedResourcesCommonFile(config)
-    ) + productFiles(config) + typedResourceFiles(typedResources)
+        typedResourcesCommonFile(config),
+        typedCustomObjectsCommonFile(config)
+    ) + productFiles(config) + typedResourceFiles(typedResources) + typedCustomObjectFiles(config)
 
 fun productFiles(config: Configuration): List<FileSpec> =
     config.productTypes.map {
@@ -98,4 +99,22 @@ fun typedResourcesCommonFile(config: Configuration) =
     FileSpec
         .builder("${config.packageName}.custom_fields", "common")
         .addType(typedResourceInterface(config))
+        .build()
+
+fun typedCustomObjectFiles(config: Configuration): List<FileSpec> =
+    config.customObjectTypes
+        .map { (containerName, className) ->
+            typedCustomObject(containerName, className, config)
+        }
+        .map { (className, typeSpec) ->
+            FileSpec
+                .builder("${config.packageName}.custom_objects", className.simpleName)
+                .addType(typeSpec)
+                .build()
+        }
+
+fun typedCustomObjectsCommonFile(config: Configuration) =
+    FileSpec
+        .builder("${config.packageName}.custom_objects", "common")
+        .addType(typedCustomObjectInterface(config))
         .build()

--- a/commercetools-sdk-java-api-customtypes-generator/src/test/kotlin/de/akii/commercetools/api/customtypes/GeneratorKtTest.kt
+++ b/commercetools-sdk-java-api-customtypes-generator/src/test/kotlin/de/akii/commercetools/api/customtypes/GeneratorKtTest.kt
@@ -35,7 +35,7 @@ internal class GeneratorKtTest {
                 javaClass.getResource("/types/types.json"),
                 object : TypeReference<List<Type>>() {})
 
-    private val config = Configuration("test.package", listOf(productType), types)
+    private val config = Configuration("test.package", listOf(productType), types, emptyMap())
 
     private val testProducts = javaClass.getResource("/products/testProducts.json")
 
@@ -47,7 +47,7 @@ internal class GeneratorKtTest {
 
     @Test
     fun `it compiles without any product-types or custom field types`() {
-        val sourceFiles = generate(Configuration("test.package", emptyList(), emptyList())).map {
+        val sourceFiles = generate(Configuration("test.package", emptyList(), emptyList(), emptyMap())).map {
             SourceFile.kotlin("${it.packageName}.${it.name}.kt", it.toString())
         }
 

--- a/commercetools-sdk-java-api-customtypes-generator/src/test/kotlin/de/akii/commercetools/api/customtypes/generator/model/CustomFieldsKtTest.kt
+++ b/commercetools-sdk-java-api-customtypes-generator/src/test/kotlin/de/akii/commercetools/api/customtypes/generator/model/CustomFieldsKtTest.kt
@@ -21,7 +21,7 @@ internal class CustomFieldsKtTest {
 
     @Test
     fun `generates typed custom fields`() {
-        val config = Configuration("test.package", listOf(), types)
+        val config = Configuration("test.package", listOf(), types, emptyMap())
         val file = customFieldsFile(config)
         val sourceFiles = listOf(
             SourceFile.kotlin("${file.name}.kt", file.toString())

--- a/commercetools-sdk-java-api-customtypes-generator/src/test/kotlin/de/akii/commercetools/api/customtypes/generator/model/TypedProductKtTest.kt
+++ b/commercetools-sdk-java-api-customtypes-generator/src/test/kotlin/de/akii/commercetools/api/customtypes/generator/model/TypedProductKtTest.kt
@@ -27,7 +27,7 @@ internal class TypedProductKtTest {
 
     @Test
     fun `generates custom product classes`() {
-        val config = Configuration("test.package", listOf(productType), emptyList())
+        val config = Configuration("test.package", listOf(productType), emptyList(), emptyMap())
         val files = listOf(
             productCommonFile(config)
         ) + productFiles(config)

--- a/commercetools-sdk-java-api-customtypes-generator/src/test/kotlin/de/akii/commercetools/api/customtypes/generator/model/TypedResourceKtTest.kt
+++ b/commercetools-sdk-java-api-customtypes-generator/src/test/kotlin/de/akii/commercetools/api/customtypes/generator/model/TypedResourceKtTest.kt
@@ -24,7 +24,7 @@ internal class TypedResourceKtTest {
 
     @Test
     fun `generates typed resources`() {
-        val config = Configuration("test.package", listOf(), types)
+        val config = Configuration("test.package", listOf(), types, emptyMap())
         val files = typedResourceFiles(typedResources(config)) + customFieldsFile(config) + typedResourcesCommonFile(config)
 
         val sourceFiles = files.map {

--- a/commercetools-sdk-java-api-customtypes-gradle-plugin/src/main/kotlin/de/akii/commercetools/api/customtypes/plugin/gradle/CustomTypesGeneratorGradlePlugin.kt
+++ b/commercetools-sdk-java-api-customtypes-gradle-plugin/src/main/kotlin/de/akii/commercetools/api/customtypes/plugin/gradle/CustomTypesGeneratorGradlePlugin.kt
@@ -74,6 +74,7 @@ class CustomTypesGeneratorGradlePlugin : Plugin<Project> {
 
         val productTypesGeneratorExtension = extension.productTypesGeneratorExtension
         val typesGeneratorExtension = extension.typesGeneratorExtension
+        val customObjectGeneratorExtension = extension.customObjectGeneratorExtension
 
         generateCustomTypesTask.packageName.convention(project.provider { extension.packageName })
         generateCustomTypesTask.productTypeToKey.convention(project.provider { productTypesGeneratorExtension.productTypeToKey })
@@ -86,6 +87,8 @@ class CustomTypesGeneratorGradlePlugin : Plugin<Project> {
         generateCustomTypesTask.fieldToPropertyName.convention(project.provider { typesGeneratorExtension.fieldToPropertyName })
         generateCustomTypesTask.isFieldRequired.convention(project.provider { typesGeneratorExtension.isFieldRequired })
         generateCustomTypesTask.productTypesFile.set(productTypesGeneratorExtension.productTypesFile)
+        generateCustomTypesTask.containerTypes.convention(project.provider { customObjectGeneratorExtension.containerTypes })
+        generateCustomTypesTask.containerNameToClassName.convention(project.provider { customObjectGeneratorExtension.containerNameToClassName })
         configureDefaultProjectSourceSet(project, generateCustomTypesTask.outputDirectory)
 
         if (extension.credentialsConfigured()) {

--- a/commercetools-sdk-java-api-customtypes-gradle-plugin/src/main/kotlin/de/akii/commercetools/api/customtypes/plugin/gradle/CustomTypesGeneratorPluginExtension.kt
+++ b/commercetools-sdk-java-api-customtypes-gradle-plugin/src/main/kotlin/de/akii/commercetools/api/customtypes/plugin/gradle/CustomTypesGeneratorPluginExtension.kt
@@ -28,6 +28,10 @@ open class CustomTypesGeneratorPluginExtension {
         CustomTypesGeneratorConfiguration()
     }
 
+    internal val customObjectGeneratorExtension: CustomObjectTypesGeneratorConfiguration by lazy {
+        CustomObjectTypesGeneratorConfiguration()
+    }
+
     /** Name of the package for all generated classes */
     var packageName: String? = null
 
@@ -41,6 +45,10 @@ open class CustomTypesGeneratorPluginExtension {
 
     fun customFields(action: Action<CustomTypesGeneratorConfiguration>) {
         action.execute(typesGeneratorExtension)
+    }
+
+    fun customObjects(action: Action<CustomObjectTypesGeneratorConfiguration>) {
+        action.execute(customObjectGeneratorExtension)
     }
 
     internal fun credentialsConfigured(): Boolean = credentialsConfigured
@@ -151,4 +159,12 @@ open class CustomTypesGeneratorConfiguration {
      * The default implementation marks all fields as not required because the commercetools platform cannot guarantee fields are set.
      */
     var isFieldRequired: (type: Type, fieldDefinition: FieldDefinition) -> Boolean = ::isFieldRequired
+}
+
+open class CustomObjectTypesGeneratorConfiguration {
+
+    var containerTypes: Map<String, String> = emptyMap()
+
+    var containerNameToClassName: (containerName: String, className: String) -> String = ::containerNameToClassName
+
 }

--- a/commercetools-sdk-java-api-customtypes-gradle-plugin/src/main/kotlin/de/akii/commercetools/api/customtypes/plugin/gradle/tasks/GenerateCustomTypesTask.kt
+++ b/commercetools-sdk-java-api-customtypes-gradle-plugin/src/main/kotlin/de/akii/commercetools/api/customtypes/plugin/gradle/tasks/GenerateCustomTypesTask.kt
@@ -64,6 +64,12 @@ abstract class GenerateCustomTypesTask : DefaultTask() {
     @Internal
     val isFieldRequired: Property<(Type, FieldDefinition) -> Boolean> = project.objects.property(Any::class.java) as Property<(Type, FieldDefinition) -> Boolean>
 
+    @Internal
+    val containerTypes: Property<Map<String, String>> = project.objects.property(Any::class.java) as Property<Map<String, String>>
+
+    @Internal
+    val containerNameToClassName: Property<(String, String) -> String> = project.objects.property(Any::class.java) as Property<(String, String) -> String>
+
     @OutputDirectory
     val outputDirectory: DirectoryProperty = project.objects.directoryProperty()
 
@@ -102,6 +108,7 @@ abstract class GenerateCustomTypesTask : DefaultTask() {
             packageName.get(),
             productTypes,
             types,
+            containerTypes.get(),
             productTypeToKey = { type -> productTypeToKey.get()(type) },
             productTypeToClassName = { type, classType -> productTypeToClassName.get()(type, classType) },
             attributeToPropertyName = { type, attribute -> attributeToPropertyName.get()(type, attribute) },
@@ -110,7 +117,8 @@ abstract class GenerateCustomTypesTask : DefaultTask() {
             typeToCustomFieldsClassName = { type -> typeToCustomFieldsClassName.get()(type) },
             typeToResourceClassName = { type, resourceName -> typeToResourceClassName.get()(type, resourceName) },
             fieldToPropertyName = { type, field -> fieldToPropertyName.get()(type, field) },
-            isFieldRequired = { type, field -> isFieldRequired.get()(type, field) }
+            isFieldRequired = { type, field -> isFieldRequired.get()(type, field) },
+            containerNameToClassName = { containerName, className -> containerNameToClassName.get()(containerName, className) }
         )
 
         val files = generate(config)


### PR DESCRIPTION
The idea is to configure JSON schemas for container names.

Usually, Custom Objects inside a container share the same type. We can use this to generate
* a deserializer that narrows the type via container name
* a type based on the JSON schema as well as a typed CustomObject implementation
* a JSON deserializer modifier that handles Kotlin's delegation

Essentially, handling Custom Objects would not differ from how Product Types and Custom Fields are handled already.

```kotlin
// Test.kt, generated by JSON schema
package some.package.custom_objects

data class Test(
  val id: String
)
```

```kotlin
// TestCustomObject.kt
package some.package.custom_objects

data class TestCustomObject(
  `delegate`: CustomObjectImpl,
  private val value: Test
) : CustomObject by delegate, TypedCustomObject
```